### PR TITLE
CP-100 Move definitions to attachSettings() function

### DIFF
--- a/tests/src/Unit/EvaluationTest.php
+++ b/tests/src/Unit/EvaluationTest.php
@@ -26,11 +26,9 @@ class EvaluationTest extends UnitTestCase {
     protected $evaluator;
 
     /**
-     * Implements setUp().
+     * Sets up all the settings for the mock decision objects within the tests.
      */
-    protected function setUp(): void {
-        parent::setUp();
-
+    protected function attachSettings(): void {
         $attach_settings = [];
 
         // Settings for Is True condition type.
@@ -438,45 +436,50 @@ class EvaluationTest extends UnitTestCase {
     }
 
     /**
+     * Implements setUp().
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->attachSettings();
+    }
+
+    /**
      * Test is_true condition type evaluation.
      */
     public function testEvaluateIsTrue(): void {
-        $key = 'is_true';
-        $this->_evaluateDecisions($key);
+        $this->_evaluateDecisions('is_true');
     }
 
     /**
      * Test default segment evaluation.
      */
     public function testEvaluateDefault(): void {
-        $key = 'default_segment';
-        $this->_evaluateDecisions($key);
+        $this->_evaluateDecisions('default_segment');
     }
 
     /**
      * Test smart_cdn:geo condition type evaluation.
      */
     public function testEvaluateGeo(): void {
-        $key = 'smart_cdn:geo';
-        $this->_evaluateDecisions($key);
+        $this->_evaluateDecisions('smart_cdn:geo');
     }
 
     /**
      * Test smart_cdn:interest condition type evaluation.
      */
     public function testEvaluateInterest(): void {
-        $key = 'smart_cdn:interest';
-        $this->_evaluateDecisions($key);
+        $this->_evaluateDecisions('smart_cdn:interest');
     }
 
     protected function _evaluateDecisions($key): void {
-        if (!empty($this->decisions[$key])) {
-            // Loop through decisions by $key.
-            foreach ($this->decisions[$key] as $decision) {
-                // Get segment id from decision evaluation.
-                $segment_id = $this->evaluator->evaluate($decision);
-                $this->assertEquals('segmentC', $segment_id);
-            }
+        // Ensure the decision key exists.
+        $this->assertArrayHasKey($key, $this->decisions);
+
+        // Loop through decisions by $key.
+        foreach ($this->decisions[$key] as $decision) {
+            // Get segment id from decision evaluation.
+            $segment_id = $this->evaluator->evaluate($decision);
+            $this->assertEquals('segmentC', $segment_id);
         }
     }
 


### PR DESCRIPTION
@jazzsequence I agree breaking up setUp() is a good idea. This also cleans up `_evaluateDecisions()` a bit.