### PR TITLE
[EI-96] Fix module errors

### DIFF
--- a/smart_content_cdn.module
+++ b/smart_content_cdn.module
@@ -6,7 +6,7 @@
  */
 
 use Drupal\Core\Entity\EntityInterface;
-use Kalamuna\SmartCDN\HeaderData;
+use Pantheon\EI\HeaderData;
 
 /**
  * Implements hook_block_view_BASE_BLOCK_ID_alter() for smart_content_decision_block().

--- a/src/EventSubscriber/HeaderEventSubscriber.php
+++ b/src/EventSubscriber/HeaderEventSubscriber.php
@@ -5,7 +5,7 @@ namespace Drupal\smart_content_cdn\EventSubscriber;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Kalamuna\SmartCDN\HeaderData;
+use Pantheon\EI\HeaderData;
 
 /**
  * Main HeaderEventSubscriber class.

--- a/src/Form/SmartContentCDNConfigForm.php
+++ b/src/Form/SmartContentCDNConfigForm.php
@@ -4,7 +4,7 @@ namespace Drupal\smart_content_cdn\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Kalamuna\SmartCDN\HeaderData;
+use Pantheon\EI\HeaderData;
 
 /**
  * Contains Smart Content CDN configuration form.

--- a/src/Plugin/smart_content/Condition/SmartCDNCondition.php
+++ b/src/Plugin/smart_content/Condition/SmartCDNCondition.php
@@ -3,7 +3,7 @@
 namespace Drupal\smart_content_cdn\Plugin\smart_content\Condition;
 
 use Drupal\smart_content\Condition\ConditionTypeConfigurableBase;
-use Kalamuna\SmartCDN\HeaderData;
+use Pantheon\EI\HeaderData;
 
 /**
  * Provides a default Smart Condition.


### PR DESCRIPTION
After activating this on a Drupal site per the [docs](https://pr-7103--pantheon-docs.my.pantheonfrontend.website/docs/guides/edge-integrations/module-install/#configure-smart-content-cdn), I encountered this error:
`Error: Class 'Kalamuna\SmartCDN\HeaderData' not found in smart_content_cdn_page_attachments() (line 116 of /code/web/modules/contrib/smart_content _cdn/smart_content_cdn.module) #0`, and one other that I'll open a separate issue for.

Edit: created #13. 