### PR TITLE
EI-96: Fixes the event subscriber filter

### DIFF
--- a/src/EventSubscriber/HeaderEventSubscriber.php
+++ b/src/EventSubscriber/HeaderEventSubscriber.php
@@ -3,7 +3,7 @@
 namespace Drupal\smart_content_cdn\EventSubscriber;
 
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Pantheon\EI\HeaderData;
 
@@ -23,10 +23,10 @@ class HeaderEventSubscriber implements EventSubscriberInterface {
   /**
    * This method is called when the kernel.response is dispatched.
    *
-   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
    *   The dispatched event.
    */
-  public function onRespond(ResponseEvent $event) {
+  public function onRespond(FilterResponseEvent $event) {
     $config = \Drupal::configFactory()->get('smart_content_cdn.config');
 
     $response = $event->getResponse();


### PR DESCRIPTION
@jspellman814 @jazzsequence I have fixed the error for the wrong type. Tested it out, don't see it on my local anymore. For the missing HeaderData class. Until repository for the Pantheon Edge Integrations Header Data is released to packagist here is the extra step for the installation:

in root Drupal composer.json file (that is on the same level as your web directory) add the following in the repositories array

``` {
        "type": "package",
        "package": {
          "name": "pantheon-systems/pantheon-edge-integrations",
          "type": "library",
          "version": "1.0.0",
          "dist": {
            "url": "https://github.com/pantheon-systems/pantheon-edge-integrations/archive/refs/heads/main.zip",
            "type": "zip"
          },
          "require": {
            "composer/installers": "~1.0"
          },
          "autoload": {
                "psr-4": {
                    "Pantheon\\EI\\": "src"
                }
            }
        }
      },
```
after that in the root of Drupal installation run `composer require pantheon-systems/pantheon-edge-integrations`. Once the library package is released as composer package, we should be able to omit this step and it will be pulled with composer file of the module.

I didn't want to update module composer file since it's correct for the future use so this is a short-term work-around. Let's chat tomorrow during our check in if you have any questions. Thanks.