### PR TITLE
EI-15: Sets smart_content_block as required

### DIFF
--- a/smart_content_cdn.info.yml
+++ b/smart_content_cdn.info.yml
@@ -6,3 +6,4 @@ core_version_requirement: ^8 || ^9
 package: Smart Content
 dependencies:
   - smart_content
+  - smart_content_block


### PR DESCRIPTION
@jspellman814 you needed to also enable Smart Content Block module. I set it as a dependency so people don't forget to enable it :) I also enabled it on your demo site.